### PR TITLE
Fix GetIpAddress DNS resolution issue in Docker

### DIFF
--- a/VNPAY.NET/Utilities/NetworkHelper.cs
+++ b/VNPAY.NET/Utilities/NetworkHelper.cs
@@ -17,11 +17,12 @@ namespace VNPAY.NET.Utilities
 
             if (remoteIpAddress != null)
             {
-                var ipv4Address = Dns.GetHostEntry(remoteIpAddress).AddressList.FirstOrDefault(x => x.AddressFamily == AddressFamily.InterNetwork);
+                if (remoteIpAddress.IsIPv4MappedToIPv6)
+                {
+                    return remoteIpAddress.MapToIPv4().ToString();
+                }
 
-                return remoteIpAddress.AddressFamily == AddressFamily.InterNetworkV6 && ipv4Address != null
-                    ? ipv4Address.ToString()
-                    : remoteIpAddress.ToString();
+                return remoteIpAddress.ToString();
             }
 
             throw new InvalidOperationException("Không tìm thấy địa chỉ IP");


### PR DESCRIPTION
### Summary

This pull request addresses the issue reported in [#2](https://github.com/phanxuanquang/VNPAY.NET/issues/2), where the `GetIpAddress` method may not function correctly in Docker environments due to DNS resolution limitations.

### Problem

When running inside a Docker container, `Dns.GetHostEntry` may fail to resolve `RemoteIpAddress` correctly due to restricted or unreliable DNS behavior inside containers. This can lead to incorrect IP retrieval or runtime exceptions.

### Solution

To improve robustness and avoid reliance on DNS, the method now checks if the incoming address is an IPv4-mapped IPv6 address, and if so, maps it directly to IPv4 using `MapToIPv4()`.

### Code Changes

**Before:**
```csharp
var ipv4Address = Dns.GetHostEntry(remoteIpAddress).AddressList.FirstOrDefault(x => x.AddressFamily == AddressFamily.InterNetwork);
```
**After**
```csharp
if (remoteIpAddress.IsIPv4MappedToIPv6)
{
    return remoteIpAddress.MapToIPv4().ToString();
}

```
This change ensures compatibility with Docker and similar environments.

**Related Issue**
Closes #2